### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   extension-ci:
     uses: steadybit/extension-kit/.github/workflows/reusable-extension-ci.yml@main # NOSONAR githubactions:S7637 - our own action
     with:
-      go_version: '^1.25.9'
+      go_version: '^1.26.2'
       build_linux_packages: true
       VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}
     secrets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Bump Go to 1.26.2
+
 ## v1.2.1
 
 - Bump Go to 1.25.9

--- a/extk6/common.go
+++ b/extk6/common.go
@@ -44,8 +44,8 @@ func getActionDescription(actionId string, label string, description string, hin
 		Label:       label,
 		Description: description,
 		Version:     extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:        extutil.Ptr(actionIcon),
-		Technology:  extutil.Ptr("K6"),
+		Icon:        new(actionIcon),
+		Technology:  new("K6"),
 		Kind:        action_kit_api.LoadTest,
 		TimeControl: action_kit_api.TimeControlInternal,
 		Hint:        hint,
@@ -53,27 +53,27 @@ func getActionDescription(actionId string, label string, description string, hin
 			{
 				Name:        "file",
 				Label:       "K6 Script",
-				Description: extutil.Ptr("Upload your K6 Script"),
+				Description: new("Upload your K6 Script"),
 				Type:        action_kit_api.ActionParameterTypeFile,
-				Required:    extutil.Ptr(true),
-				AcceptedFileTypes: extutil.Ptr([]string{
+				Required:    new(true),
+				AcceptedFileTypes: new([]string{
 					".js",
 				}),
-				Order: extutil.Ptr(1),
+				Order: new(1),
 			},
 			{
 				Name:        "environment",
 				Label:       "Environment variables",
-				Description: extutil.Ptr("Environment variables which will be accessible in your k6 script by ${__ENV.foobar}"),
+				Description: new("Environment variables which will be accessible in your k6 script by ${__ENV.foobar}"),
 				Type:        action_kit_api.ActionParameterTypeKeyValue,
-				Required:    extutil.Ptr(false),
-				Order:       extutil.Ptr(2),
+				Required:    new(false),
+				Order:       new(2),
 			},
 		},
-		Status: extutil.Ptr(action_kit_api.MutatingEndpointReferenceWithCallInterval{
-			CallInterval: extutil.Ptr("5s"),
+		Status: new(action_kit_api.MutatingEndpointReferenceWithCallInterval{
+			CallInterval: new("5s"),
 		}),
-		Stop: extutil.Ptr(action_kit_api.MutatingEndpointReference{}),
+		Stop: new(action_kit_api.MutatingEndpointReference{}),
 	}
 }
 
@@ -171,7 +171,7 @@ func status(state *K6LoadTestRunState) (*action_kit_api.StatusResult, error) {
 	messages := stdOutToMessages(stdOut)
 	log.Debug().Msgf("Returning %d messages", len(messages))
 
-	result.Messages = extutil.Ptr(messages)
+	result.Messages = new(messages)
 	return &result, nil
 }
 
@@ -195,7 +195,7 @@ func substringAfter(value string, a string) *string {
 	if adjustedPos >= len(value) {
 		return nil
 	}
-	return extutil.Ptr(value[adjustedPos:])
+	return new(value[adjustedPos:])
 }
 
 func stdOutToLog(lines []string) {
@@ -340,8 +340,8 @@ func stop(state *K6LoadTestRunState) (*action_kit_api.StopResult, error) {
 
 	log.Debug().Msgf("Returning %d messages", len(messages))
 	return &action_kit_api.StopResult{
-		Artifacts: extutil.Ptr(artifacts),
-		Messages:  extutil.Ptr(messages),
+		Artifacts: new(artifacts),
+		Messages:  new(messages),
 	}, nil
 }
 

--- a/extk6/common_test.go
+++ b/extk6/common_test.go
@@ -1,7 +1,6 @@
 package extk6
 
 import (
-	"github.com/steadybit/extension-kit/extutil"
 	"reflect"
 	"testing"
 )
@@ -16,7 +15,7 @@ func Test_substringAfter(t *testing.T) {
 		args args
 		want *string
 	}{
-		{name: "match", args: args{value: "abc", after: "b"}, want: extutil.Ptr("c")},
+		{name: "match", args: args{value: "abc", after: "b"}, want: new("c")},
 		{name: "no match", args: args{value: "aaa", after: "b"}, want: nil},
 		{name: "no match after last", args: args{value: "abc", after: "c"}, want: nil},
 		{name: "empty", args: args{value: "", after: "b"}, want: nil},
@@ -39,7 +38,7 @@ func Test_extractErrorFromStdOut(t *testing.T) {
 		args args
 		want *string
 	}{
-		{name: "match", args: args{lines: []string{"abc", "def", "level=error msg=something"}}, want: extutil.Ptr("something")},
+		{name: "match", args: args{lines: []string{"abc", "def", "level=error msg=something"}}, want: new("something")},
 		{name: "no match", args: args{lines: []string{"abc", "def", "level=debug msg=something"}}, want: nil},
 	}
 	for _, tt := range tests {

--- a/extk6/discovery.go
+++ b/extk6/discovery.go
@@ -10,7 +10,6 @@ import (
 	"github.com/steadybit/discovery-kit/go/discovery_kit_sdk"
 	"github.com/steadybit/extension-k6/config"
 	"github.com/steadybit/extension-kit/extbuild"
-	"github.com/steadybit/extension-kit/extutil"
 	"os"
 )
 
@@ -32,7 +31,7 @@ func (e *k6LocationDiscovery) Describe() discovery_kit_api.DiscoveryDescription 
 	return discovery_kit_api.DiscoveryDescription{
 		Id: targetType,
 		Discover: discovery_kit_api.DescribingEndpointReferenceWithCallInterval{
-			CallInterval: extutil.Ptr(fmt.Sprintf("%ds", 300)),
+			CallInterval: new(fmt.Sprintf("%ds", 300)),
 		},
 	}
 }
@@ -41,9 +40,9 @@ func (e *k6LocationDiscovery) DescribeTarget() discovery_kit_api.TargetDescripti
 	return discovery_kit_api.TargetDescription{
 		Id:       targetType,
 		Label:    discovery_kit_api.PluralLabel{One: "K6 Location", Other: "K6 Locations"},
-		Category: extutil.Ptr("execution locations"),
+		Category: new("execution locations"),
 		Version:  extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:     extutil.Ptr(targetIcon),
+		Icon:     new(targetIcon),
 
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{

--- a/extk6/run_cloud_test.go
+++ b/extk6/run_cloud_test.go
@@ -20,15 +20,15 @@ import (
 func TestPrepareExtractsState(t *testing.T) {
 	// Given
 	request := extutil.JsonMangle(action_kit_api.PrepareActionRequestBody{
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"duration": 1000 * 60,
 			"notify":   true,
 			"file":     "test.js",
 		},
 		Target: nil,
-		ExecutionContext: extutil.Ptr(action_kit_api.ExecutionContext{
-			ExperimentUri: extutil.Ptr("<uri-to-experiment>"),
-			ExecutionUri:  extutil.Ptr("<uri-to-execution>"),
+		ExecutionContext: new(action_kit_api.ExecutionContext{
+			ExperimentUri: new("<uri-to-experiment>"),
+			ExecutionUri:  new("<uri-to-execution>"),
 		}),
 	})
 	action := k6LoadTestCloudAction{}

--- a/extk6/run_local.go
+++ b/extk6/run_local.go
@@ -44,11 +44,11 @@ func (l *K6LoadTestRunAction) Describe() action_kit_api.ActionDescription {
 			Name:  "-",
 			Label: "Filter K6 Locations",
 			Type:  action_kit_api.ActionParameterTypeTargetSelection,
-			Order: extutil.Ptr(3),
+			Order: new(3),
 		})
-		description.TargetSelection = extutil.Ptr(action_kit_api.TargetSelection{
+		description.TargetSelection = new(action_kit_api.TargetSelection{
 			TargetType: targetType,
-			DefaultBlastRadius: extutil.Ptr(action_kit_api.DefaultBlastRadius{
+			DefaultBlastRadius: new(action_kit_api.DefaultBlastRadius{
 				Mode:  action_kit_api.DefaultBlastRadiusModeMaximum,
 				Value: 1,
 			}),

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steadybit/extension-k6
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5


### PR DESCRIPTION
## Summary
- Bump Go to 1.26.2 in go.mod, ci.yml, and Dockerfile
- Apply `go fix ./...` changes