### PR TITLE
chore: update to k6 v1.8.0

### DIFF
--- a/.trivyignore.yml
+++ b/.trivyignore.yml
@@ -1,1 +1,6 @@
 vulnerabilities:
+  - id: CVE-2026-42154
+    paths:
+      - usr/local/bin/k6
+    statement: Wait for a new K6-Release
+    expired_at: 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Update to k6 v1.8.0
+
 ## v1.2.4
 
 - Support discovery group attribute via `STEADYBIT_EXTENSION_DISCOVERY_GROUP` env var (or `discovery.group` Helm value) — when set, the extension adds `steadybit.group=<value>` to every discovered target

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS k6-builder
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG K6_VERSION=v1.7.1
+ARG K6_VERSION=v1.8.0
 
 RUN apk add --no-cache git
 RUN go install go.k6.io/xk6/cmd/xk6@v1.4.1


### PR DESCRIPTION
## Summary
- Bump `K6_VERSION` to `v1.8.0` in the Dockerfile
- Ignore CVE-2026-42154 in the k6 binary (expires 2026-09-01) — waiting for upstream
- Add changelog entry under `(next)`

## Test plan
- [x] `go test ./...` — passes (extk6 + e2e against Minikube, 250s)
- [x] `make charttesting` — 29 tests pass
- [x] `go vet ./...` — clean