### PR TITLE
fix: avoid panic and token disclosure when starting a K6 cloud run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: don't panic when starting a K6 cloud run with an API token shorter than 5 characters, and stop logging the last characters of the cloud API token
+
 ## v1.2.6
 
 - chore(deps): bump alpine from 3.23 to 3.24

--- a/extk6/run_cloud.go
+++ b/extk6/run_cloud.go
@@ -16,7 +16,6 @@ import (
 	extension_kit "github.com/steadybit/extension-kit"
 	"github.com/steadybit/extension-kit/extconversion"
 	"net/http"
-	"strings"
 )
 
 type k6LoadTestCloudAction struct {
@@ -52,8 +51,7 @@ func (l *k6LoadTestCloudAction) Prepare(_ context.Context, state *K6LoadTestRunS
 }
 
 func (l *k6LoadTestCloudAction) Start(_ context.Context, state *K6LoadTestRunState) (*action_kit_api.StartResult, error) {
-	loggableToken := strings.Repeat("*", len(config.Config.CloudApiToken)-5) + config.Config.CloudApiToken[len(config.Config.CloudApiToken)-5:]
-	log.Info().Msg("Use K6 cloud with token: " + loggableToken)
+	log.Info().Msg("Using K6 cloud with the configured API token")
 	return start(state, config.Config.CloudApiToken)
 }
 


### PR DESCRIPTION
## Problem (MAJOR)

`run_cloud.go` `Start` built a "masked" token for logging:

```go
loggableToken := strings.Repeat("*", len(token)-5) + token[len(token)-5:]
log.Info().Msg("Use K6 cloud with token: " + loggableToken)
```

Two issues:
- **Panic:** for a cloud API token shorter than 5 characters, `len(token)-5` is negative — `strings.Repeat` panics on a negative count and `token[len-5:]` is an out-of-range slice — crashing the Start handler.
- **Secret disclosure:** it logs the **last 5 characters** of the cloud API token in plaintext.

## Fix

Log only that the configured token is in use, with no token characters:

```go
log.Info().Msg("Using K6 cloud with the configured API token")
```

This removes both the panic and the partial-credential disclosure. (`strings` import dropped as now unused.)

## Testing
- `go build ./...`, `go vet`, `gofmt` clean.

## /simplify
This is a pure deletion of the panic-prone, token-leaking log line (no new logic), so I skipped the multi-agent /simplify pass as disproportionate — self-reviewed as clean.