### PR TITLE
fix: resolve data race on the process exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: don't panic when starting a K6 cloud run with an API token shorter than 5 characters, and stop logging the last characters of the cloud API token
+- fix: resolve the data race on the K6 process exit code between the process-reaping goroutine and the status/stop handlers (via `extcmd.CmdState.Wait`/`ExitCode`)
 
 ## v1.2.6
 

--- a/extk6/common.go
+++ b/extk6/common.go
@@ -112,7 +112,7 @@ func start(state *K6LoadTestRunState, token string) (*action_kit_api.StartResult
 
 	state.Pid = cmd.Process.Pid
 	go func() {
-		cmdErr := cmd.Wait()
+		cmdErr := cmdState.Wait()
 		if cmdErr != nil {
 			log.Warn().Msgf("Failed to execute k6: %s", cmdErr)
 		}
@@ -134,7 +134,7 @@ func status(state *K6LoadTestRunState) (*action_kit_api.StatusResult, error) {
 	var result action_kit_api.StatusResult
 
 	// check if k6 is still running
-	exitCode := cmdState.Cmd.ProcessState.ExitCode()
+	exitCode := cmdState.ExitCode()
 	stdOut := cmdState.GetLines(false)
 	addCloudRunIdToState(stdOut, state)
 	stdOutToLog(stdOut)
@@ -264,7 +264,7 @@ func stop(state *K6LoadTestRunState) (*action_kit_api.StopResult, error) {
 	messages := stdOutToMessages(stdOut)
 
 	// read return code and send it as Message
-	exitCode := cmdState.Cmd.ProcessState.ExitCode()
+	exitCode := cmdState.ExitCode()
 	if exitCode != 0 && exitCode != -1 {
 		messages = append(messages, action_kit_api.Message{
 			Level:   extutil.Ptr(action_kit_api.Error),

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1
 	github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5
-	github.com/steadybit/extension-kit v1.10.4
+	github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd
 	github.com/stretchr/testify v1.11.1
 	k8s.io/client-go v0.36.2
 )

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/steadybit/action-kit/go/action_kit_test v1.4.7
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1
 	github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5
-	github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd
+	github.com/steadybit/extension-kit v1.10.6
 	github.com/stretchr/testify v1.11.1
 	k8s.io/client-go v0.36.2
 )

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5 h1:1yT/4Aw+lQvYXS
 github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5/go.mod h1:gOPfHZ3hw/7TMxEYCCTYnOz9tZ2ybNYa+MKmUbPXKIQ=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1 h1:CabRtfE70gt/4H/TgL/TRm54OkxWKbmPhTX2qEhzKZ4=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1/go.mod h1:PPJh5gSdVRKG/0qJCGJK5XnGxXat/v6UT8/2ilIbbX8=
-github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd h1:g3NImsC9j6XyarW9zNUvpkVAPHu2X6ulrPiKe2jvhoI=
-github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
+github.com/steadybit/extension-kit v1.10.6 h1:Qz73OO7EMBpueJZjQ23wDXE0xOLBpJOz6h2ND7t6d0s=
+github.com/steadybit/extension-kit v1.10.6/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5 h1:1yT/4Aw+lQvYXS
 github.com/steadybit/discovery-kit/go/discovery_kit_sdk v1.3.5/go.mod h1:gOPfHZ3hw/7TMxEYCCTYnOz9tZ2ybNYa+MKmUbPXKIQ=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1 h1:CabRtfE70gt/4H/TgL/TRm54OkxWKbmPhTX2qEhzKZ4=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1/go.mod h1:PPJh5gSdVRKG/0qJCGJK5XnGxXat/v6UT8/2ilIbbX8=
-github.com/steadybit/extension-kit v1.10.4 h1:/XJH43+WepBz0xX7vPTB0X+nJeAB0Hu1fmB/mkecM+4=
-github.com/steadybit/extension-kit v1.10.4/go.mod h1:nHO0lQixaBUC2ynInJ3g2fQXoEqcoP6Qn3Iq2mcpQ4E=
+github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd h1:g3NImsC9j6XyarW9zNUvpkVAPHu2X6ulrPiKe2jvhoI=
+github.com/steadybit/extension-kit v1.10.6-0.20260630192502-059086860afd/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=


### PR DESCRIPTION
## Problem

`Start` reaped the process in a goroutine (`go cmd.Wait()`, which writes `cmd.ProcessState`) while `Status`/`Stop` read `cmdState.Cmd.ProcessState.ExitCode()` concurrently — a data race that `go test -race` flags and that can yield torn reads of the process result.

## Fix

Use the shared **`extcmd.CmdState.Wait()` / `ExitCode()`** API added in [extension-kit#149](https://github.com/steadybit/extension-kit/pull/149): `CmdState` owns the process result, `Wait()` is the sole reader of `cmd.ProcessState`, and `ExitCode()` returns it race-free (`-1` while running). `Start` now does `go cmdState.Wait()`; the handlers read `cmdState.ExitCode()`.

This is the same fix applied across the four extensions that share this `extcmd` pattern (extension-gatling, extension-jmeter, extension-k6, extension-postman).

## Dependency

`extension-kit` is pinned to the unreleased commit (`v1.10.6-0.20260630192502-059086860afd`) until #149 is merged and tagged; the pin should be bumped to the tagged release before merge.

## Verification

`go build ./...`, `go vet ./...`, `go test -race ./...` pass.
