### PR TITLE
feat: update bundled k6 to v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.0
+
+- feat: update bundled k6 to v2.1.0
+- fix: adapt to k6 v2 cloud CLI change (`k6 cloud run` instead of `k6 cloud`)
+
 ## v1.2.9
 
 - ci: skip build on .trivyignore.yml-only changes [skip ci]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS k6-builder
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG K6_VERSION=v1.8.0
+ARG K6_VERSION=v2.1.0
 
 RUN apk add --no-cache git
 RUN go install go.k6.io/xk6/cmd/xk6@v1.4.1

--- a/extk6/run_cloud.go
+++ b/extk6/run_cloud.go
@@ -46,7 +46,7 @@ func (l *k6LoadTestCloudAction) Prepare(_ context.Context, state *K6LoadTestRunS
 	if err := extconversion.Convert(request.Config, &runConfig); err != nil {
 		return nil, extension_kit.ToError("Failed to unmarshal the runConfig.", err)
 	}
-	command := []string{"k6", "cloud", runConfig.File}
+	command := []string{"k6", "cloud", "run", runConfig.File}
 	return prepare(state, request, command)
 }
 

--- a/extk6/run_cloud_test.go
+++ b/extk6/run_cloud_test.go
@@ -40,7 +40,7 @@ func TestPrepareExtractsState(t *testing.T) {
 	// Then
 	require.Nil(t, result)
 	require.Nil(t, err)
-	require.Equal(t, state.Command, []string([]string{"k6", "cloud", "test.js"}))
+	require.Equal(t, state.Command, []string([]string{"k6", "cloud", "run", "test.js"}))
 }
 
 func TestFailedCommandStart(t *testing.T) {


### PR DESCRIPTION
## What

Update the k6 binary shipped in the Docker image from `v1.8.0` to `v2.1.0`.

## Changes

- **Dockerfile**: bump `K6_VERSION` from `v1.8.0` to `v2.1.0`.
- **extk6/run_cloud.go**: adapt to the k6 v2.0.0 cloud CLI change — `k6 cloud <file>` → `k6 cloud run <file>`.
- **extk6/run_cloud_test.go**: update the expected command assertion.
- **CHANGELOG.md**: add `v1.3.0` entry.

## Notes

Reviewed the k6 v2.0.0 changelog against this codebase; the cloud CLI rename is the only breaking change that applies:

- The extension shells out to the `k6` binary and does not import k6 Go packages, so the `go.k6.io/k6` → `/v2` module-path change does not affect it.
- xk6 `v1.4.1` (already pinned) supports building k6 v2 — major-version module-path resolution landed in xk6 v1.4.0, so no xk6 bump is needed.
- `k6 run`, `--no-usage-report`, and `--out json=...` remain valid in v2, so `run_local.go` is unchanged.
- Removed commands/flags (`externally-controlled`, `--no-summary`, `k6 login`, `--upload-only`) are not used here.
- v2.1.0 itself introduces no breaking changes.

Build passes and the affected tests are green.